### PR TITLE
Bugfix XML 1.0 conformity

### DIFF
--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -866,6 +866,15 @@ mbus_data_product_name(mbus_data_variable_header *header)
                     break;
             }
         }
+        else if (manufacturer == MBUS_VARIABLE_DATA_MAN_SEN)
+        {
+            switch (header->version)
+            {
+                case 0x19:
+                    strcpy(buff,"Sensus PolluCom E");
+                    break;
+            }
+        }
         else if (manufacturer == MBUS_VARIABLE_DATA_MAN_SPX) 
         {
             switch (header->version)

--- a/mbus/mbus-protocol.h
+++ b/mbus/mbus-protocol.h
@@ -484,6 +484,7 @@ typedef struct _mbus_data_secondary_address {
 #define MBUS_VARIABLE_DATA_MAN_NZR              0x3B52
 #define MBUS_VARIABLE_DATA_MAN_PAD              0x4024
 #define MBUS_VARIABLE_DATA_MAN_QDS              0x4493
+#define MBUS_VARIABLE_DATA_MAN_SEN              0x4CAE
 #define MBUS_VARIABLE_DATA_MAN_SLB              0x4D82
 #define MBUS_VARIABLE_DATA_MAN_SON              0x4DEE
 #define MBUS_VARIABLE_DATA_MAN_SPX              0x4E18


### PR DESCRIPTION
- convert invalid control characters into spaces to avoid problems with XML parser (e.g. xsltproc)
- add Sensus PolluCom E model mapping
