### PR TITLE
Improve debian build scripts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: libmbus
 Priority: extra
 Maintainer: Robert Johansson <rob@raditex.nu>
-Build-Depends: debhelper (>= 7.0.50~), autotools-dev, autoconf
+Build-Depends: debhelper (>= 7.0.50~), dh-autoreconf
 Standards-Version: 3.8.4
 Section: libs
 Homepage: http://www.rscada.se/libmbus

--- a/debian/files
+++ b/debian/files
@@ -1,2 +1,0 @@
-libmbus-dev_0.8.0_amd64.deb libdevel extra
-libmbus1_0.8.0_amd64.deb libs extra

--- a/debian/libmbus-dev.install
+++ b/debian/libmbus-dev.install
@@ -2,3 +2,4 @@ usr/include/*
 usr/lib/lib*.a
 usr/lib/lib*.so
 usr/lib/*.la
+usr/lib/pkgconfig/libmbus.pc

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@
+	dh --with autoreconf $@
 
 #override_dh_auto_configure:
 #	dh_auto_configure -- --prefix=/usr/local/freescada


### PR DESCRIPTION
1. Add calling autoreconf to debian/rules for purpose of automatic build
   in chroot environment with pbuilder.
2. Copy missing pkg-config file libmbus.pc to /usr/lib/pkgconfig/
3. Remove unnecessary (IMHO) debian/files, becouse it automaticly deletes
   by debian/rules clean action
