### PR TITLE
fixes for automake 1.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,9 @@ AC_CONFIG_AUX_DIR([libltdl/config])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AM_PROG_LIBTOOL
+#fix for automake 1.12
+m4_pattern_allow([AM_PROG_AR])
+AM_PROG_AR
 
 LDFLAGS="$LDFLAGS -version-info 0:8:0"
 


### PR DESCRIPTION
Hi rscada-team,

your configure.ac failed on my machine with automake 1.12. I fixed the issues regarding automake 1.12.

Cheers,
tpltnt
