### PR TITLE
Add a function to calculate the manufacturer ID from the 3 byte ASCII

### DIFF
--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -22,18 +22,38 @@ static char error_str[512];
 #define NITEMS(x) (sizeof(x)/sizeof(x[0]))
 
 //------------------------------------------------------------------------------
-// Return the manufacturer ID according to the manufacturer's 3 byte ASCII code
+// Returns the manufacturer ID according to the manufacturer's 3 byte ASCII code
+// or zero when there was an error.
 //------------------------------------------------------------------------------
 unsigned int
 mbus_manufacturer_id(char *manufacturer)
 {
     unsigned int id;
 
+    /*
+     * manufacturer must consist of at least 3 alphabetic characters,
+     * additional chars are silently ignored.
+     */
+
+    if (!manufacturer || strlen(manufacturer) < 3)
+        return 0;
+
+    if (!isalpha(manufacturer[0]) ||
+        !isalpha(manufacturer[1]) ||
+        !isalpha(manufacturer[2]))
+        return 0;
+
     id = (toupper(manufacturer[0]) - 64) * 32 * 32 +
          (toupper(manufacturer[1]) - 64) * 32 +
          (toupper(manufacturer[2]) - 64);
 
-    return id;
+    /*
+     * Valid input data should be in the range of 'AAA' to 'ZZZ' according to
+     * the FLAG Association (http://www.dlms.com/flag/), thus resulting in
+     * an ID from 0x0421 to 0x6b5a. If the conversion results in anything not
+     * in this range, simply discard it and return 0 instead.
+     */
+    return (0x0421 <= id && id <= 0x6b5a) ? id : 0;
 }
 
 //------------------------------------------------------------------------------

--- a/mbus/mbus-protocol.h
+++ b/mbus/mbus-protocol.h
@@ -493,7 +493,8 @@ typedef struct _mbus_data_secondary_address {
 #define MBUS_VARIABLE_DATA_MEDIUM_ADC           0x19
 
 //
-// Return manufacturer ID
+// Returns the manufacturer ID or zero if the given
+// string could not be converted into an ID
 //
 unsigned int mbus_manufacturer_id(char *manufacturer);
 


### PR DESCRIPTION
code. The formula can be found at http://www.m-bus.com/files/w4b21021.pdf,
chapter 3.3 at page 6.

This obsoletes the static defines, so remove them.

Signed-off-by: Michael Heimpold mhei@heimpold.de
