### PR TITLE
add codepage to XML output

### DIFF
--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -1373,6 +1373,8 @@ mbus_data_variable_xml_normalized(mbus_data_variable *data)
         if (buff == NULL)
             return NULL;
 
+        len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
+
         len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
         len += snprintf(&buff[len], buff_size - len, "%s", mbus_data_variable_header_xml(&(data->header)));

--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -3779,6 +3779,8 @@ mbus_data_variable_xml(mbus_data_variable *data)
         if (buff == NULL)
             return NULL;
 
+        len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
+
         len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
         len += snprintf(&buff[len], buff_size - len, "%s",
@@ -3828,6 +3830,8 @@ mbus_data_fixed_xml(mbus_data_fixed *data)
 
         if (buff == NULL)
             return NULL;
+
+        len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
 
         len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
@@ -3902,6 +3906,7 @@ mbus_data_error_xml(int error)
     if (buff == NULL)
         return NULL;
 
+    len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
     len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
     len += snprintf(&buff[len], buff_size - len, "    <SlaveInformation>\n");
@@ -4002,6 +4007,8 @@ mbus_frame_xml(mbus_frame *frame)
             // include frame counter in XML output if more than one frame
             // is available (frame_cnt = -1 => not included in output)
             frame_cnt = (frame->next == NULL) ? -1 : 0;
+
+            len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
 
             len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 

--- a/mbus/mbus-protocol.h
+++ b/mbus/mbus-protocol.h
@@ -498,6 +498,10 @@ typedef struct _mbus_data_secondary_address {
 //
 unsigned int mbus_manufacturer_id(char *manufacturer);
 
+// Since libmbus writes some special characters (ASCII > 0x7F) into the XML output (e.g. °C for centigrade == ASCII 0xB0)
+// it is useful to attach the appropriate code page for postprocessing.
+#define MBUS_XML_PROCESSING_INSTRUCTION         "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
+
 //
 // Event callback functions
 //


### PR DESCRIPTION
Since libmbus writes some special characters (ASCII > 0x7F) into the XML output (e.g. °C for centigrade == ASCII 0xB0) it is useful to attach the appropriate code page for postprocessing.