### PR TITLE
Beautify tabs and spaces

### DIFF
--- a/bin/mbus-serial-request-data-multi-reply.c
+++ b/bin/mbus-serial-request-data-multi-reply.c
@@ -216,6 +216,3 @@ main(int argc, char **argv)
 
     return 0;
 }
-
-
-

--- a/bin/mbus-serial-scan-secondary.c
+++ b/bin/mbus-serial-scan-secondary.c
@@ -135,7 +135,7 @@ main(int argc, char **argv)
         free(addr_mask);
         return 1;
     }
-    
+
     if (debug)
     {
         mbus_register_send_event(handle, &mbus_dump_send_event);

--- a/bin/mbus-serial-scan.c
+++ b/bin/mbus-serial-scan.c
@@ -113,7 +113,7 @@ main(int argc, char **argv)
         fprintf(stderr,"Scan failed: Could not initialize M-Bus context: %s\n",  mbus_error_str());
         return 1;
     }
-    
+
     if (debug)
     {
         mbus_register_send_event(handle, &mbus_dump_send_event);

--- a/bin/mbus-serial-select-secondary.c
+++ b/bin/mbus-serial-select-secondary.c
@@ -97,7 +97,7 @@ main(int argc, char **argv)
     if (mbus_frame_type(&reply) == MBUS_FRAME_TYPE_ACK)
     {
         if (mbus_send_request_frame(handle, MBUS_ADDRESS_NETWORK_LAYER) == -1)
-	    {
+        {
             fprintf(stderr,"Failed to send request to selected secondary device: %s\n", mbus_error_str());
             return 1;
         }

--- a/bin/mbus-tcp-raw-send.c
+++ b/bin/mbus-tcp-raw-send.c
@@ -30,7 +30,7 @@ main(int argc, char **argv)
     int address, result;
     FILE *fp = NULL;
     size_t buff_len, len;
-  	unsigned char raw_buff[4096], buff[4096];
+    unsigned char raw_buff[4096], buff[4096];
 
     memset((void *)&reply, 0, sizeof(mbus_frame));
     memset((void *)&reply_data, 0, sizeof(mbus_frame_data));
@@ -191,6 +191,4 @@ main(int argc, char **argv)
     mbus_context_free(handle);
     return 0;
 }
-
-
 

--- a/bin/mbus-tcp-select-secondary.c
+++ b/bin/mbus-tcp-select-secondary.c
@@ -88,7 +88,7 @@ main(int argc, char **argv)
     if (mbus_frame_type(&reply) == MBUS_FRAME_TYPE_ACK)
     {
         if (mbus_send_request_frame(handle, MBUS_ADDRESS_NETWORK_LAYER) == -1)
-	    {
+        {
             fprintf(stderr,"Failed to send request to selected secondary device: %s\n", mbus_error_str());
             return 1;
         }

--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -214,13 +214,13 @@ mbus_variable_vif vif_table[] = {
 
     /* E111 1010 Bus Address */
     { 0x7A, 1.0, "", "Bus Address" },
-    
+
     /* Any VIF: 7Eh */
     { 0x7E, 1.0, "", "Any VIF" },
-    
+
     /* Manufacturer specific: 7Fh */
     { 0x7F, 1.0, "", "Manufacturer specific" },
-    
+
     /* Any VIF: 7Eh */
     { 0xFE, 1.0, "", "Any VIF" },
 
@@ -607,7 +607,7 @@ mbus_variable_vif vif_table[] = {
     { 0x255, 1.0e0, "Reserved", "Reserved" },
     { 0x256, 1.0e0, "Reserved", "Reserved" },
     { 0x257, 1.0e0, "Reserved", "Reserved" },
-    
+
     /* E101 10nn Flow Temperature 10(nn-3) °F 0.001°F to 1°F */
     { 0x258, 1.0e-3, "°F", "Flow temperature" },
     { 0x259, 1.0e-2, "°F", "Flow temperature" },
@@ -935,7 +935,7 @@ int mbus_variable_value_decode(mbus_data_record *record, double *value_out_real,
                 break;
 
             case 0x07: /* 8 byte integer (64 bit) */
-            	result = mbus_data_long_long_decode(record->data, 8, &value_out_long_long);
+                result = mbus_data_long_long_decode(record->data, 8, &value_out_long_long);
                 *value_out_real = value_out_long_long;
                 break;
 
@@ -1404,14 +1404,14 @@ mbus_data_variable_xml_normalized(mbus_data_variable *data)
             {
                 mbus_str_xml_encode(str_encoded, norm_record->function_medium, sizeof(str_encoded));
                 len += snprintf(&buff[len], buff_size - len, "        <Function>%s</Function>\n", str_encoded);
-                
+
                 len += snprintf(&buff[len], buff_size - len, "        <StorageNumber>%ld</StorageNumber>\n", norm_record->storage_number);
-            	
-            	if (norm_record->tariff >= 0)
-            	{
-	            	len += snprintf(&buff[len], buff_size - len, "        <Tariff>%ld</Tariff>\n", norm_record->tariff);
-	            	len += snprintf(&buff[len], buff_size - len, "        <Device>%d</Device>\n", norm_record->device);
-            	}
+
+                if (norm_record->tariff >= 0)
+                {
+                    len += snprintf(&buff[len], buff_size - len, "        <Tariff>%ld</Tariff>\n", norm_record->tariff);
+                    len += snprintf(&buff[len], buff_size - len, "        <Device>%d</Device>\n", norm_record->device);
+                }
 
                 mbus_str_xml_encode(str_encoded, norm_record->unit, sizeof(str_encoded));
 
@@ -1664,11 +1664,11 @@ mbus_recv_frame(mbus_handle * handle, mbus_frame *frame)
         case MBUS_CONTROL_MASK_DIR_M2S:
             if (handle->purge_first_frame == MBUS_FRAME_PURGE_M2S)
                 result = handle->recv(handle, frame);  // purge echo and retry
-    	     break;
+            break;
         case MBUS_CONTROL_MASK_DIR_S2M:
             if (handle->purge_first_frame == MBUS_FRAME_PURGE_S2M)
                 result = handle->recv(handle, frame);  // purge echo and retry
-             break;
+            break;
     }
 
     if (frame != NULL)
@@ -1831,7 +1831,7 @@ mbus_send_application_reset_frame(mbus_handle * handle, int address, int subcode
 
     if (subcode > 0xFF)
     {
-    	MBUS_ERROR("%s: invalid subcode %d\n", __PRETTY_FUNCTION__, subcode);
+        MBUS_ERROR("%s: invalid subcode %d\n", __PRETTY_FUNCTION__, subcode);
         return -1;
     }
 
@@ -2239,16 +2239,16 @@ mbus_probe_secondary_address(mbus_handle *handle, const char *mask, char *matchi
         ret = mbus_select_secondary_address(handle, mask);
 
         if (ret == MBUS_PROBE_SINGLE)
-	    {
-	        /* send a data request command to find out the full address */
-	        if (mbus_send_request_frame(handle, MBUS_ADDRESS_NETWORK_LAYER) == -1)
-	        {
-	            MBUS_ERROR("%s: Failed to send request to selected secondary device [mask %s]: %s.\n",
-	                       __PRETTY_FUNCTION__,
-	                       mask,
-	                       mbus_error_str());
-	            return MBUS_PROBE_ERROR;
-	        }
+        {
+            /* send a data request command to find out the full address */
+            if (mbus_send_request_frame(handle, MBUS_ADDRESS_NETWORK_LAYER) == -1)
+            {
+                MBUS_ERROR("%s: Failed to send request to selected secondary device [mask %s]: %s.\n",
+                           __PRETTY_FUNCTION__,
+                           mask,
+                           mbus_error_str());
+                return MBUS_PROBE_ERROR;
+            }
 
             memset((void *)&reply, 0, sizeof(mbus_frame));
             ret = mbus_recv_frame(handle, &reply);
@@ -2263,13 +2263,13 @@ mbus_probe_secondary_address(mbus_handle *handle, const char *mask, char *matchi
                 /* check for more data (collision) */
                 mbus_purge_frames(handle);
                 return MBUS_PROBE_COLLISION;
-	        }
+            }
 
             /* check for more data (collision) */
             if (mbus_purge_frames(handle))
             {
                 return MBUS_PROBE_COLLISION;
-	        }
+            }
 
             if (mbus_frame_type(&reply) == MBUS_FRAME_TYPE_LONG)
             {
@@ -2283,7 +2283,7 @@ mbus_probe_secondary_address(mbus_handle *handle, const char *mask, char *matchi
                     return MBUS_PROBE_NOTHING;
                 }
 
-	            snprintf(matching_addr, 17, "%s", addr);
+                snprintf(matching_addr, 17, "%s", addr);
 
                 if (handle->found_event)
                 {
@@ -2291,20 +2291,20 @@ mbus_probe_secondary_address(mbus_handle *handle, const char *mask, char *matchi
                 }
 
                 return MBUS_PROBE_SINGLE;
-	        }
-	        else
-	        {
-	            MBUS_ERROR("%s: Unexpected reply for address [mask %s]. Expected long frame.\n",
-	                       __PRETTY_FUNCTION__, mask);
-	            return MBUS_PROBE_NOTHING;
-	        }
-	    }
-	    else if ((ret == MBUS_PROBE_ERROR) ||
-	             (ret == MBUS_PROBE_COLLISION))
-	    {
-	    	break;
-	    }
-	}
+            }
+            else
+            {
+                MBUS_ERROR("%s: Unexpected reply for address [mask %s]. Expected long frame.\n",
+                           __PRETTY_FUNCTION__, mask);
+                return MBUS_PROBE_NOTHING;
+            }
+        }
+        else if ((ret == MBUS_PROBE_ERROR) ||
+                 (ret == MBUS_PROBE_COLLISION))
+        {
+            break;
+        }
+    }
 
     return ret;
 }

--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -1373,6 +1373,8 @@ mbus_data_variable_xml_normalized(mbus_data_variable *data)
         if (buff == NULL)
             return NULL;
 
+        len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
+
         len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
         len += snprintf(&buff[len], buff_size - len, "%s", mbus_data_variable_header_xml(&(data->header)));

--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -3779,6 +3779,8 @@ mbus_data_variable_xml(mbus_data_variable *data)
         if (buff == NULL)
             return NULL;
 
+        len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
+
         len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
         len += snprintf(&buff[len], buff_size - len, "%s",
@@ -3828,6 +3830,8 @@ mbus_data_fixed_xml(mbus_data_fixed *data)
 
         if (buff == NULL)
             return NULL;
+
+        len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
 
         len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
@@ -3902,6 +3906,7 @@ mbus_data_error_xml(int error)
     if (buff == NULL)
         return NULL;
 
+    len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
     len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 
     len += snprintf(&buff[len], buff_size - len, "    <SlaveInformation>\n");
@@ -4002,6 +4007,8 @@ mbus_frame_xml(mbus_frame *frame)
             // include frame counter in XML output if more than one frame
             // is available (frame_cnt = -1 => not included in output)
             frame_cnt = (frame->next == NULL) ? -1 : 0;
+
+            len += snprintf(&buff[len], buff_size - len, MBUS_XML_PROCESSING_INSTRUCTION);
 
             len += snprintf(&buff[len], buff_size - len, "<MBusData>\n\n");
 

--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -868,15 +868,36 @@ mbus_data_product_name(mbus_data_variable_header *header)
                     break;
             }
         }
+        else if (manufacturer == mbus_manufacturer_id("AMT"))
+        {
+            switch (header->version)
+            {
+                case 0x80:
+                    strcpy(buff,"Aquametro CALEC MB");
+                    break;
+                case 0xC0:
+                    strcpy(buff,"Aquametro CALEC ST");
+                    break;
+            }
+        }
         else if (manufacturer == mbus_manufacturer_id("EFE"))
         {
             switch (header->version)
             {
                 case 0x00:
-                    strcpy(buff, ((header->medium == 0x06) ? "Engelmann WaterStar" : "Engelmann SensoStar 2"));
+                    strcpy(buff, ((header->medium == 0x06) ? "Engelmann WaterStar" : "Engelmann / Elster SensoStar 2"));
                     break;
                 case 0x01:
                     strcpy(buff,"Engelmann SensoStar 2C");
+                    break;
+            }
+        }
+        else if (manufacturer == mbus_manufacturer_id("ELS"))
+        {
+            switch (header->version)
+            {
+                case 0x2F:
+                    strcpy(buff,"Elster F96 Plus");
                     break;
             }
         }
@@ -908,6 +929,18 @@ mbus_data_product_name(mbus_data_variable_header *header)
                 case 0x3B:
                     strcpy(buff,"Elvaco CMa11");
                     break;
+            }
+        }
+        else if (manufacturer == mbus_manufacturer_id("EMU"))
+        {
+            if (header->medium == MBUS_VARIABLE_DATA_MEDIUM_ELECTRICITY)
+            {
+                switch (header->version)
+                {
+                    case 0x10:
+                        strcpy(buff,"EMU Professional 3/75 M-Bus");
+                        break;
+                }
             }
         }
         else if (manufacturer == mbus_manufacturer_id("GMC"))
@@ -981,10 +1014,10 @@ mbus_data_product_name(mbus_data_variable_header *header)
             switch (header->version)
             {
                 case 0x08:
-                    strcpy(buff,"Elster F2");
+                    strcpy(buff,"Elster F2 / Deltamess F2");
                     break;
                 case 0x09:
-                    strcpy(buff,"Kamstrup SVM F22");
+                    strcpy(buff,"Elster F4 / Kamstrup SVM F22");
                     break;
             }
         }
@@ -1010,6 +1043,12 @@ mbus_data_product_name(mbus_data_variable_header *header)
         {
             switch (header->version)
             {
+                case 0x0B:
+                    strcpy(buff,"Sensus PolluTherm");
+                    break;
+                case 0x0E:
+                    strcpy(buff,"Sensus PolluStat E");
+                    break;
                 case 0x19:
                     strcpy(buff,"Sensus PolluCom E");
                     break;
@@ -1041,6 +1080,10 @@ mbus_data_product_name(mbus_data_variable_header *header)
                 case 0x01:
                     strcpy(buff,"NZR DHZ 5/63");
                     break;
+                case 0x50:
+                    strcpy(buff,"NZR IC-M2");
+                    break;
+
             }
         }
         else if (manufacturer == mbus_manufacturer_id("KAM"))
@@ -1085,6 +1128,20 @@ mbus_data_product_name(mbus_data_variable_header *header)
                     break;
             }
         }
+        else if (manufacturer == mbus_manufacturer_id("SBC"))
+        {
+            switch (header->id_bcd[3])
+            {
+                case 0x10:
+                case 0x19:
+                    strcpy(buff,"Saia-Burgess ALE3");
+                    break;
+                case 0x11:
+                    strcpy(buff,"Saia-Burgess AWD3");
+                    break;
+            }
+        }
+
     }
 
     return buff;

--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -523,27 +523,27 @@ mbus_data_int_decode(unsigned char *int_data, size_t int_data_size, int *value)
 
     if (!int_data || (int_data_size < 1))
     {
-    	return -1;
+        return -1;
     }
-    
+
     neg = int_data[int_data_size-1] & 0x80;
-    
+
     for (i = int_data_size; i > 0; i--)
     {
-    	if (neg)
-		{
-    		*value = (*value << 8) + (int_data[i-1] ^ 0xFF);
-    	}
-    	else
-    	{
-    		*value = (*value << 8) + int_data[i-1];
-    	}
+        if (neg)
+        {
+            *value = (*value << 8) + (int_data[i-1] ^ 0xFF);
+        }
+        else
+        {
+            *value = (*value << 8) + int_data[i-1];
+        }
     }
 
     if (neg)
-	{
-		*value = *value * -1 - 1;
-	}
+    {
+        *value = *value * -1 - 1;
+    }
 
     return 0;
 }
@@ -557,27 +557,27 @@ mbus_data_long_decode(unsigned char *int_data, size_t int_data_size, long *value
 
     if (!int_data || (int_data_size < 1))
     {
-    	return -1;
+        return -1;
     }
     
     neg = int_data[int_data_size-1] & 0x80;
     
     for (i = int_data_size; i > 0; i--)
     {
-    	if (neg)
-		{
-    		*value = (*value << 8) + (int_data[i-1] ^ 0xFF);
-    	}
-    	else
-    	{
-    		*value = (*value << 8) + int_data[i-1];
-    	}
+        if (neg)
+        {
+            *value = (*value << 8) + (int_data[i-1] ^ 0xFF);
+        }
+        else
+        {
+            *value = (*value << 8) + int_data[i-1];
+        }
     }
 
     if (neg)
-	{
-		*value = *value * -1 - 1;
-	}
+    {
+        *value = *value * -1 - 1;
+    }
 
     return 0;
 }
@@ -591,27 +591,27 @@ mbus_data_long_long_decode(unsigned char *int_data, size_t int_data_size, long l
 
     if (!int_data || (int_data_size < 1))
     {
-    	return -1;
+        return -1;
     }
-    
+
     neg = int_data[int_data_size-1] & 0x80;
-    
+
     for (i = int_data_size; i > 0; i--)
     {
-    	if (neg)
-		{
-    		*value = (*value << 8) + (int_data[i-1] ^ 0xFF);
-    	}
-    	else
-    	{
-    		*value = (*value << 8) + int_data[i-1];
-    	}
+        if (neg)
+        {
+            *value = (*value << 8) + (int_data[i-1] ^ 0xFF);
+        }
+        else
+        {
+            *value = (*value << 8) + int_data[i-1];
+        }
     }
 
     if (neg)
-	{
-		*value = *value * -1 - 1;
-	}
+    {
+        *value = *value * -1 - 1;
+    }
 
     return 0;
 }
@@ -949,7 +949,7 @@ mbus_data_product_name(mbus_data_variable_header *header)
             {
                 case 0xE6:
                     strcpy(buff,"GMC-I A230 EMMOD 206");
-                	break;
+                    break;
             }
         }
         else if (manufacturer == mbus_manufacturer_id("SLB"))
@@ -993,12 +993,12 @@ mbus_data_product_name(mbus_data_variable_header *header)
         }
         else if (manufacturer == mbus_manufacturer_id("RAM"))
         {
-        	switch (header->version)
-        	{
-        		case 0x03:
-        			strcpy(buff, "Rossweiner ETK/ETW Modularis");
-        			break;
-        	}
+            switch (header->version)
+            {
+                case 0x03:
+                    strcpy(buff, "Rossweiner ETK/ETW Modularis");
+                    break;
+            }
         }
         else if (manufacturer == mbus_manufacturer_id("RKE"))
         {
@@ -1702,48 +1702,47 @@ mbus_unit_prefix(int exp)
 unsigned char
 mbus_dif_datalength_lookup(unsigned char dif)
 {
-	switch (dif & MBUS_DATA_RECORD_DIF_MASK_DATA)
-	{
-		case 0x0:
-			return 0;
-		case 0x1:
-			return 1;
-		case 0x2:
-			return 2;
-		case 0x3:
-			return 3;
-		case 0x4:
-			return 4;
-		case 0x5:
-			return 4;
-		case 0x6:
-			return 6;
-		case 0x7:
-			return 8;
-
-		case 0x8:
-			return 0;
-		case 0x9:
-			return 1;
-		case 0xA:
-			return 2;
-		case 0xB:
-			return 3;
-		case 0xC:
-			return 4;
-		case 0xD:
+    switch (dif & MBUS_DATA_RECORD_DIF_MASK_DATA)
+    {
+        case 0x0:
+            return 0;
+        case 0x1:
+            return 1;
+        case 0x2:
+            return 2;
+        case 0x3:
+            return 3;
+        case 0x4:
+            return 4;
+        case 0x5:
+            return 4;
+        case 0x6:
+            return 6;
+        case 0x7:
+            return 8;
+        case 0x8:
+            return 0;
+        case 0x9:
+            return 1;
+        case 0xA:
+            return 2;
+        case 0xB:
+            return 3;
+        case 0xC:
+            return 4;
+        case 0xD:
             // variable data length,
             // data length stored in data field
-			return 0;
-		case 0xE:
-			return 6;
-		case 0xF:
-			return 8;
+            return 0;
+        case 0xE:
+            return 6;
+        case 0xF:
+            return 8;
 
-		default: // never reached
-			return 0x00;
+        default: // never reached
+            return 0x00;
 
-	}
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -1947,7 +1946,7 @@ mbus_vif_unit_lookup(unsigned char vif)
         // nn = 10   hours
         // nn = 11    days
         // E010 01nn Operating Time coded like OnTime
-        // E111 00nn Averaging Duration	coded like OnTime
+        // E111 00nn Averaging Duration coded like OnTime
         // E111 01nn Actuality Duration coded like OnTime
         case 0x20:
         case 0x20+1:
@@ -2209,10 +2208,10 @@ mbus_vib_unit_lookup(mbus_value_information_block *vib)
             snprintf(buff, sizeof(buff), "Password");
         }
         else if (vib->vife[0] == 0x17 || vib->vife[0] == 0x97)
-		{
+        {
             // VIFE = E001 0111 Error flags
             snprintf(buff, sizeof(buff), "Error flags");
-		}
+        }
         else if (vib->vife[0] == 0x10)
         {
             // VIFE = E001 0000 Customer location
@@ -2545,25 +2544,25 @@ mbus_data_record_value(mbus_data_record *record)
 //------------------------------------------------------------------------------
 long mbus_data_record_storage_number(mbus_data_record *record)
 {
-	int bit_index = 0;
-	long result = 0;
-	int i;
+    int bit_index = 0;
+    long result = 0;
+    int i;
 
-	if (record)
-	{
-		result |= (record->drh.dib.dif & MBUS_DATA_RECORD_DIF_MASK_STORAGE_NO) >> 6;
-		bit_index++;
-	
-		for (i=0; i<record->drh.dib.ndife; i++)
-		{
-			result |= (record->drh.dib.dife[i] & MBUS_DATA_RECORD_DIFE_MASK_STORAGE_NO) << bit_index;
-			bit_index += 4;
-		}
-		
-		return result;
-	}
-	
-	return -1;
+    if (record)
+    {
+        result |= (record->drh.dib.dif & MBUS_DATA_RECORD_DIF_MASK_STORAGE_NO) >> 6;
+        bit_index++;
+
+        for (i=0; i<record->drh.dib.ndife; i++)
+        {
+            result |= (record->drh.dib.dife[i] & MBUS_DATA_RECORD_DIFE_MASK_STORAGE_NO) << bit_index;
+            bit_index += 4;
+        }
+
+        return result;
+    }
+
+    return -1;
 }
 
 //------------------------------------------------------------------------------
@@ -2571,22 +2570,22 @@ long mbus_data_record_storage_number(mbus_data_record *record)
 //------------------------------------------------------------------------------
 long mbus_data_record_tariff(mbus_data_record *record)
 {
-	int bit_index = 0;
-	long result = 0;
-	int i;
-	
-	if (record && (record->drh.dib.ndife > 0))
-	{
-		for (i=0; i<record->drh.dib.ndife; i++)
-		{
-			result |= ((record->drh.dib.dife[i] & MBUS_DATA_RECORD_DIFE_MASK_TARIFF) >> 4) << bit_index;
-			bit_index += 2;
-		}
-		
-		return result;
-	}
+    int bit_index = 0;
+    long result = 0;
+    int i;
 
-	return -1;
+    if (record && (record->drh.dib.ndife > 0))
+    {
+        for (i=0; i<record->drh.dib.ndife; i++)
+        {
+            result |= ((record->drh.dib.dife[i] & MBUS_DATA_RECORD_DIFE_MASK_TARIFF) >> 4) << bit_index;
+            bit_index += 2;
+        }
+
+        return result;
+    }
+
+    return -1;
 }
 
 //------------------------------------------------------------------------------
@@ -2594,22 +2593,22 @@ long mbus_data_record_tariff(mbus_data_record *record)
 //------------------------------------------------------------------------------
 int mbus_data_record_device(mbus_data_record *record)
 {
-	int bit_index = 0;
-	int result = 0;
-	int i;
+    int bit_index = 0;
+    int result = 0;
+    int i;
 
-	if (record && (record->drh.dib.ndife > 0))
-	{
-		for (i=0; i<record->drh.dib.ndife; i++)
-		{
-			result |= ((record->drh.dib.dife[i] & MBUS_DATA_RECORD_DIFE_MASK_DEVICE) >> 6) << bit_index;
-			bit_index++;
-		}
-		
-		return result;
-	}
+    if (record && (record->drh.dib.ndife > 0))
+    {
+        for (i=0; i<record->drh.dib.ndife; i++)
+        {
+            result |= ((record->drh.dib.dife[i] & MBUS_DATA_RECORD_DIFE_MASK_DEVICE) >> 6) << bit_index;
+            bit_index++;
+        }
 
-	return -1;
+        return result;
+    }
+
+    return -1;
 }
 
 //------------------------------------------------------------------------------
@@ -3561,7 +3560,7 @@ mbus_data_variable_print(mbus_data_variable *data)
 int
 mbus_data_fixed_print(mbus_data_fixed *data)
 {
-	int val;
+    int val;
 
     if (data)
     {
@@ -3574,12 +3573,11 @@ mbus_data_fixed_print(mbus_data_fixed *data)
         printf("%s: Unit1    = %s\n", __PRETTY_FUNCTION__, mbus_data_fixed_unit(data->cnt1_type));
         if ((data->status & MBUS_DATA_FIXED_STATUS_FORMAT_MASK) == MBUS_DATA_FIXED_STATUS_FORMAT_BCD)
         {
-        	val = mbus_data_bcd_decode(data->cnt1_val, 4);
+            val = mbus_data_bcd_decode(data->cnt1_val, 4);
         }
         else
         {
-        	mbus_data_int_decode(data->cnt1_val, 4, &val);
-            
+            mbus_data_int_decode(data->cnt1_val, 4, &val);
         }
         printf("%s: Counter1 = %d\n", __PRETTY_FUNCTION__, val);
 
@@ -3780,19 +3778,18 @@ mbus_data_variable_record_xml(mbus_data_record *record, int record_cnt, int fram
             mbus_str_xml_encode(str_encoded, mbus_data_record_function(record), sizeof(str_encoded));
             len += snprintf(&buff[len], sizeof(buff) - len,
                             "        <Function>%s</Function>\n", str_encoded);
-                            
+
             len += snprintf(&buff[len], sizeof(buff) - len,
-            				"        <StorageNumber>%ld</StorageNumber>\n",
-            				mbus_data_record_storage_number(record));
-            	
-        	
-        	if ((tariff = mbus_data_record_tariff(record)) >= 0)
-        	{
-            	len += snprintf(&buff[len], sizeof(buff) - len, "        <Tariff>%ld</Tariff>\n",
-            					tariff);
-            	len += snprintf(&buff[len], sizeof(buff) - len, "        <Device>%d</Device>\n", 
-            					mbus_data_record_device(record));
-        	}
+                            "        <StorageNumber>%ld</StorageNumber>\n",
+                            mbus_data_record_storage_number(record));
+
+            if ((tariff = mbus_data_record_tariff(record)) >= 0)
+            {
+                len += snprintf(&buff[len], sizeof(buff) - len, "        <Tariff>%ld</Tariff>\n",
+                                tariff);
+                len += snprintf(&buff[len], sizeof(buff) - len, "        <Device>%d</Device>\n", 
+                                mbus_data_record_device(record));
+            }
 
             mbus_str_xml_encode(str_encoded, mbus_data_record_unit(record), sizeof(str_encoded));
             len += snprintf(&buff[len], sizeof(buff) - len,

--- a/mbus/mbus-protocol.h
+++ b/mbus/mbus-protocol.h
@@ -498,6 +498,10 @@ typedef struct _mbus_data_secondary_address {
 //
 unsigned int mbus_manufacturer_id(char *manufacturer);
 
+// Since libmbus writes some special characters (ASCII > 0x7F) into the XML output (e.g. °C for centigrade == ASCII 0xB0)
+// it is useful to attach the appropriate code page for postprocessing.
+#define MBUS_XML_PROCESSING_INSTRUCTION         "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
+
 //
 // Event callback functions
 //

--- a/mbus/mbus-serial.c
+++ b/mbus/mbus-serial.c
@@ -372,5 +372,3 @@ mbus_serial_recv_frame(mbus_handle *handle, mbus_frame *frame)
     return MBUS_RECV_RESULT_OK;
 }
 
-
-

--- a/mbus/mbus-serial.h
+++ b/mbus/mbus-serial.h
@@ -33,18 +33,16 @@ typedef struct _mbus_serial_data
     struct termios t;
 } mbus_serial_data;
 
-int                 mbus_serial_connect(mbus_handle *handle);
-int                 mbus_serial_disconnect(mbus_handle *handle);
-int                 mbus_serial_send_frame(mbus_handle *handle, mbus_frame *frame);
-int                 mbus_serial_recv_frame(mbus_handle *handle, mbus_frame *frame);
-int                 mbus_serial_set_baudrate(mbus_handle *handle, long baudrate);
-void                mbus_serial_data_free(mbus_handle *handle);
+int  mbus_serial_connect(mbus_handle *handle);
+int  mbus_serial_disconnect(mbus_handle *handle);
+int  mbus_serial_send_frame(mbus_handle *handle, mbus_frame *frame);
+int  mbus_serial_recv_frame(mbus_handle *handle, mbus_frame *frame);
+int  mbus_serial_set_baudrate(mbus_handle *handle, long baudrate);
+void mbus_serial_data_free(mbus_handle *handle);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* MBUS_SERIAL_H */
-
-
 

--- a/test/mbus_parse.c
+++ b/test/mbus_parse.c
@@ -20,10 +20,10 @@ main(int argc, char *argv[])
     FILE *fp = NULL;
     size_t buff_len, len;
     int normalized = 0;
-	unsigned char buf[1024];
-	mbus_frame reply;
-	mbus_frame_data frame_data;
-	char *xml_result = NULL, *file = NULL;
+    unsigned char buf[1024];
+    mbus_frame reply;
+    mbus_frame_data frame_data;
+    char *xml_result = NULL, *file = NULL;
 
     if (argc == 3 && strcmp(argv[1], "-n") == 0)
     {
@@ -47,8 +47,8 @@ main(int argc, char *argv[])
         return 1;
     }
 
-	memset(buf, 0, sizeof(buf));
-	len = fread(buf, 1, sizeof(buf), fp);
+    memset(buf, 0, sizeof(buf));
+    len = fread(buf, 1, sizeof(buf), fp);
 
     if (ferror(fp) != 0)
     {
@@ -56,17 +56,17 @@ main(int argc, char *argv[])
         return 1;
     }
 
-	fclose(fp);
+    fclose(fp);
 
-	memset(&reply, 0, sizeof(reply));
-	memset(&frame_data, 0, sizeof(frame_data));
-	mbus_parse(&reply, buf, len);
-	mbus_frame_data_parse(&reply, &frame_data);
-	mbus_frame_print(&reply);
+    memset(&reply, 0, sizeof(reply));
+    memset(&frame_data, 0, sizeof(frame_data));
+    mbus_parse(&reply, buf, len);
+    mbus_frame_data_parse(&reply, &frame_data);
+    mbus_frame_print(&reply);
 
-	xml_result = normalized ? mbus_frame_data_xml_normalized(&frame_data) : mbus_frame_data_xml(&frame_data);
+    xml_result = normalized ? mbus_frame_data_xml_normalized(&frame_data) : mbus_frame_data_xml(&frame_data);
 
-	if (xml_result == NULL)
+    if (xml_result == NULL)
     {
         fprintf(stderr, "Failed to generate XML representation of MBUS frame: %s\n", mbus_error_str());
         return 1;
@@ -74,7 +74,6 @@ main(int argc, char *argv[])
     printf("%s", xml_result);
     free(xml_result);
 
-	return 0;
+    return 0;
 }
-
 

--- a/test/mbus_parse_hex.c
+++ b/test/mbus_parse_hex.c
@@ -19,13 +19,13 @@ main(int argc, char *argv[])
 {
     FILE *fp = NULL;
     size_t buff_len, len;
-	int result, normalized = 0;
-	unsigned char raw_buff[4096], buff[4096];
-	mbus_frame reply;
-	mbus_frame_data frame_data;
-	char *xml_result = NULL, *file = NULL;
+    int result, normalized = 0;
+    unsigned char raw_buff[4096], buff[4096];
+    mbus_frame reply;
+    mbus_frame_data frame_data;
+    char *xml_result = NULL, *file = NULL;
 
-	if (argc == 3 && strcmp(argv[1], "-n") == 0)
+    if (argc == 3 && strcmp(argv[1], "-n") == 0)
     {
         file = argv[2];
         normalized = 1;
@@ -60,16 +60,16 @@ main(int argc, char *argv[])
 
     buff_len = mbus_hex2bin(buff,sizeof(buff),raw_buff,sizeof(raw_buff));
 
-	memset(&reply, 0, sizeof(reply));
-	memset(&frame_data, 0, sizeof(frame_data));
+    memset(&reply, 0, sizeof(reply));
+    memset(&frame_data, 0, sizeof(frame_data));
 
-	//mbus_parse_set_debug(1);
+    //mbus_parse_set_debug(1);
 
-	result = mbus_parse(&reply, buff, buff_len);
+    result = mbus_parse(&reply, buff, buff_len);
 
-	if (result < 0)
-	{
-	    fprintf(stderr, "mbus_parse: %s\n", mbus_error_str());
+    if (result < 0)
+    {
+        fprintf(stderr, "mbus_parse: %s\n", mbus_error_str());
         return 1;
     }
     else if (result > 0)
@@ -80,10 +80,10 @@ main(int argc, char *argv[])
 
     result = mbus_frame_data_parse(&reply, &frame_data);
 
-	if (result != 0)
-	{
-	    mbus_frame_print(&reply);
-	    fprintf(stderr, "mbus_frame_data_parse: %s\n", mbus_error_str());
+    if (result != 0)
+    {
+        mbus_frame_print(&reply);
+        fprintf(stderr, "mbus_frame_data_parse: %s\n", mbus_error_str());
         return 1;
     }
 
@@ -97,11 +97,10 @@ main(int argc, char *argv[])
         fprintf(stderr, "Failed to generate XML representation of MBUS frame: %s\n", mbus_error_str());
         return 1;
     }
-	printf("%s", xml_result);
-	free(xml_result);
-	mbus_data_record_free(frame_data.data_var.record);
+    printf("%s", xml_result);
+    free(xml_result);
+    mbus_data_record_free(frame_data.data_var.record);
 
-	return 0;
+    return 0;
 }
-
 


### PR DESCRIPTION
Beautify: replace tabs with spaces and remove trailing spaces
I'm not very common with the libmbus source code, but I think I learned from early commits that tabs and trailing spaces are not welcome within the source. So replaced the tabs and removes trailing spaces. No functional impact.