### PR TITLE
Add hint file for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+script: ./build.sh


### PR DESCRIPTION
Using Travis CI for automated builds on each commit can improve code quality. For example, compiling the sources using clang spots several warnings at the moment.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>