### PR TITLE
Add optional reset-before-request-data

### DIFF
--- a/bin/mbus-serial-request-data.c
+++ b/bin/mbus-serial-request-data.c
@@ -15,37 +15,8 @@
 
 static int debug = 0;
 
-//
-// init slave to get really the beginning of the records
-//
-static int
-init_slaves(mbus_handle *handle)
-{
-    if (debug)
-        printf("%s: debug: sending init frame #1\n", __PRETTY_FUNCTION__);
-
-    if (mbus_send_ping_frame(handle, MBUS_ADDRESS_NETWORK_LAYER, 1) == -1)
-    {
-        return 0;
-    }
-
-    //
-    // resend SND_NKE, maybe the first get lost
-    //
-
-    if (debug)
-        printf("%s: debug: sending init frame #2\n", __PRETTY_FUNCTION__);
-
-    if (mbus_send_ping_frame(handle, MBUS_ADDRESS_NETWORK_LAYER, 1) == -1)
-    {
-        return 0;
-    }
-
-    return 1;
-}
-
 //------------------------------------------------------------------------------
-// Scan for devices using secondary addressing.
+// request one frame of data from a slave
 //------------------------------------------------------------------------------
 int
 main(int argc, char **argv)
@@ -98,7 +69,7 @@ main(int argc, char **argv)
         fprintf(stderr, "Could not initialize M-Bus context: %s\n",  mbus_error_str());
         return 1;
     }
-    
+
     if (debug)
     {
         mbus_register_send_event(handle, &mbus_dump_send_event);
@@ -120,8 +91,9 @@ main(int argc, char **argv)
         return 1;
     }
 
-    if (init_slaves(handle) == 0)
+    if (mbus_send_ping_frame(handle,MBUS_ADDRESS_NETWORK_LAYER, 1) == -1)
     {
+        fprintf(stderr,"Failed to init/de-select slave.\n");
         mbus_disconnect(handle);
         mbus_context_free(handle);
         return 1;
@@ -157,7 +129,7 @@ main(int argc, char **argv)
             return 1;
         }
         // else MBUS_PROBE_SINGLE
-        
+
         address = MBUS_ADDRESS_NETWORK_LAYER;
     }
     else
@@ -223,6 +195,4 @@ main(int argc, char **argv)
     mbus_context_free(handle);
     return 0;
 }
-
-
 

--- a/bin/mbus-serial-scan-secondary.c
+++ b/bin/mbus-serial-scan-secondary.c
@@ -115,6 +115,8 @@ main(int argc, char **argv)
     if (mbus_connect(handle) == -1)
     {
         fprintf(stderr,"Failed to setup connection to M-bus gateway\n");
+        mbus_disconnect(handle);
+        mbus_context_free(handle);
         free(addr_mask);
         return 1;
     }
@@ -122,6 +124,8 @@ main(int argc, char **argv)
     if (mbus_serial_set_baudrate(handle, baudrate) == -1)
     {
         fprintf(stderr, "Failed to set baud rate.\n");
+        mbus_disconnect(handle);
+        mbus_context_free(handle);
         free(addr_mask);
         return 1;
     }
@@ -132,6 +136,8 @@ main(int argc, char **argv)
     if (frame == NULL)
     {
         fprintf(stderr, "Failed to allocate mbus frame.\n");
+        mbus_disconnect(handle);
+        mbus_context_free(handle);
         free(addr_mask);
         return 1;
     }

--- a/bin/mbus-serial-scan-secondary.c
+++ b/bin/mbus-serial-scan-secondary.c
@@ -15,36 +15,6 @@
 
 static int debug = 0;
 
-//
-// init slave to get really the beginning of the records
-//
-int
-init_slaves(mbus_handle *handle)
-{
-    if (debug)
-        printf("%s: debug: sending init frame #1\n", __PRETTY_FUNCTION__);
-
-    if (mbus_send_ping_frame(handle, MBUS_ADDRESS_NETWORK_LAYER, 1) == -1)
-    {
-        return 0;
-    }
-
-    //
-    // resend SND_NKE, maybe the first get lost
-    //
-
-    if (debug)
-        printf("%s: debug: sending init frame #2\n", __PRETTY_FUNCTION__);
-
-    if (mbus_send_ping_frame(handle, MBUS_ADDRESS_BROADCAST_NOREPLY, 1) == -1)
-    {
-        return 0;
-    }
-
-    return 1;
-}
-
-
 //------------------------------------------------------------------------------
 // Scan for devices using secondary addressing.
 //------------------------------------------------------------------------------
@@ -166,8 +136,11 @@ main(int argc, char **argv)
         return 1;
     }
 
-    if (init_slaves(handle) == 0)
+    if (mbus_send_ping_frame(handle,MBUS_ADDRESS_NETWORK_LAYER, 1) == -1)
     {
+        fprintf(stderr,"Failed to init/de-select slave.\n");
+        mbus_disconnect(handle);
+        mbus_context_free(handle);
         free(addr_mask);
         return 1;
     }

--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -886,7 +886,7 @@ int mbus_variable_value_decode(mbus_data_record *record, double *value_out_real,
                 else  // normal integer
                 {
                     result = mbus_data_int_decode(record->data, 2, &value_out_int);
-                    *value_out_real = value_out_int; 
+                    *value_out_real = value_out_int;
                 }
                 break;
 
@@ -921,7 +921,7 @@ int mbus_variable_value_decode(mbus_data_record *record, double *value_out_real,
                 else  // normal integer
                 {
                     result = mbus_data_int_decode(record->data, 4, &value_out_int);
-                    *value_out_real = value_out_int; 
+                    *value_out_real = value_out_int;
                 }
                 break;
 
@@ -1261,7 +1261,7 @@ mbus_parse_variable_record(mbus_data_record *data)
         MBUS_ERROR("%s: memory allocation error\n", __PRETTY_FUNCTION__);
         return NULL;
     }
-    
+
     record->storage_number = mbus_data_record_storage_number(data);
     record->tariff = mbus_data_record_tariff(data);
     record->device = mbus_data_record_device(data);
@@ -2279,7 +2279,7 @@ mbus_probe_secondary_address(mbus_handle *handle, const char *mask, char *matchi
                 if (addr == NULL)
                 {
                     // show error message, but procede with scan
-                    MBUS_ERROR("Failed to generate secondary address from M-Bus reply frame: %s\n", 
+                    MBUS_ERROR("Failed to generate secondary address from M-Bus reply frame: %s\n",
                                mbus_error_str());
                     return MBUS_PROBE_NOTHING;
                 }


### PR DESCRIPTION
1. refactor device reset/de-select
2. add optional reset-before-request-data

This feature is needed to read Sontex Supercal 531 reliably
