### PR TITLE
Fix regression with XML output.

### DIFF
--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -4027,7 +4027,7 @@ mbus_data_fixed_xml(mbus_data_fixed *data)
         len += snprintf(&buff[len], buff_size - len, "        <Unit>%s</Unit>\n", str_encoded);
         if ((data->status & MBUS_DATA_FIXED_STATUS_FORMAT_MASK) == MBUS_DATA_FIXED_STATUS_FORMAT_BCD)
         {
-            len += snprintf(&buff[len], buff_size - len, "        <Value>%lld</Value>\n", mbus_data_bcd_decode(data->cnt1_val, 4));
+            len += snprintf(&buff[len], buff_size - len, "        <Value>%lld</Value>\n", mbus_data_bcd_decode(data->cnt2_val, 4));
         }
         else
         {


### PR DESCRIPTION
Copy-paste error from 9edcc44.

Spotted with `cd test && ./generate-xml.sh test-frames`

    --- test-frames/manual_frame2.xml	2016-05-09 00:19:44.000000000 +0200
    +++ test-frames/manual_frame2.xml.new	2016-05-09 01:09:09.000000000 +0200
    @@ -17,7 +17,7 @@
         <DataRecord id="1">
             <Function>Actual value</Function>
             <Unit>reserved but historic</Unit>
    -        <Value>135</Value>
    +        <Value>1</Value>
         </DataRecord>
    
     </MBusData>