### PR TITLE
Problem: mbus_serial_recv_frame() timeout check fails if first read()==0

### DIFF
--- a/mbus/mbus-serial.c
+++ b/mbus/mbus-serial.c
@@ -334,7 +334,7 @@ mbus_serial_recv_frame(mbus_handle *handle, mbus_frame *frame)
             }
         }
 
-        if (len > (SSIZE_MAX-nread))
+        if (len > (SSIZE_MAX - nread))
         {
             // avoid overflow
             return MBUS_RECV_RESULT_ERROR;
@@ -342,7 +342,7 @@ mbus_serial_recv_frame(mbus_handle *handle, mbus_frame *frame)
 
         len += nread;
 
-    } while ((remaining = mbus_parse(frame, buff, len)) > 0);
+    } while (len == 0 || (remaining = mbus_parse(frame, buff, len)) > 0);
 
     if (len == 0)
     {


### PR DESCRIPTION
Solution: Additionally check if len==0.

If the first read() of the loop returns with 0 the timeouts
counter is incremented but on the same time mbus_parse() will return with
remaining <= 0. Thus the 3 retires that the timeouts counters should
guarantee are skip all together.