### PR TITLE
prevent multiple calls to disconnect for serial and tcp

### DIFF
--- a/mbus/mbus-serial.c
+++ b/mbus/mbus-serial.c
@@ -191,7 +191,13 @@ mbus_serial_disconnect(mbus_handle *handle)
         return -1;
     }
 
+    if (handle->fd == -1)
+    {
+       return -1;
+    }
+
     close(handle->fd);
+    handle->fd = -1;
 
     return 0;
 }
@@ -374,4 +380,3 @@ mbus_serial_recv_frame(mbus_handle *handle, mbus_frame *frame)
 
     return MBUS_RECV_RESULT_OK;
 }
-

--- a/mbus/mbus-serial.c
+++ b/mbus/mbus-serial.c
@@ -191,7 +191,7 @@ mbus_serial_disconnect(mbus_handle *handle)
         return -1;
     }
 
-    if (handle->fd < -1)
+    if (handle->fd < 0)
     {
        return -1;
     }

--- a/mbus/mbus-serial.c
+++ b/mbus/mbus-serial.c
@@ -191,7 +191,7 @@ mbus_serial_disconnect(mbus_handle *handle)
         return -1;
     }
 
-    if (handle->fd == -1)
+    if (handle->fd < -1)
     {
        return -1;
     }

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -127,7 +127,13 @@ mbus_tcp_disconnect(mbus_handle *handle)
         return -1;
     }
 
+    if (handle->fd == -1)
+    {
+       return -1;
+    }
+
     close(handle->fd);
+    handle->fd = -1;
 
     return 0;
 }
@@ -262,4 +268,3 @@ mbus_tcp_set_timeout_set(double seconds)
 
     return 0;
 }
-

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -127,7 +127,7 @@ mbus_tcp_disconnect(mbus_handle *handle)
         return -1;
     }
 
-    if (handle->fd < -1)
+    if (handle->fd < 0)
     {
        return -1;
     }

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -127,7 +127,7 @@ mbus_tcp_disconnect(mbus_handle *handle)
         return -1;
     }
 
-    if (handle->fd == -1)
+    if (handle->fd < -1)
     {
        return -1;
     }


### PR DESCRIPTION
as discussed in one of the node-mbus issues here is my change to prevent multiple "disconnect" calls to make problems by checking it.