### PR TITLE
Update golden test files after commits 2f9fa5c, 23d8ee4 

### DIFF
--- a/test/test-frames/EFE_Engelmann-WaterStar.xml
+++ b/test/test-frames/EFE_Engelmann-WaterStar.xml
@@ -6,7 +6,7 @@
         <Manufacturer>EFE</Manufacturer>
         <Version>0</Version>
         <ProductName>Engelmann WaterStar</ProductName>
-        <Medium>Hot water</Medium>
+        <Medium>Warm water (30-90°C)</Medium>
         <AccessNumber>12</AccessNumber>
         <Status>27</Status>
         <Signature>0000</Signature>

--- a/test/test-frames/ELS_Elster-F96-Plus.xml
+++ b/test/test-frames/ELS_Elster-F96-Plus.xml
@@ -48,14 +48,14 @@
         <Function>Value during error state</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Power (W)</Unit>
-        <Value>144445223</Value>
+        <Value>13131113</Value>
     </DataRecord>
 
     <DataRecord id="5">
         <Function>Value during error state</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Volume flow (m m^3/h)</Unit>
-        <Value>1445223</Value>
+        <Value>131113</Value>
     </DataRecord>
 
     <DataRecord id="6">

--- a/test/test-frames/SLB_CF-Compact-Integral-MK-MaXX.xml
+++ b/test/test-frames/SLB_CF-Compact-Integral-MK-MaXX.xml
@@ -58,7 +58,7 @@
         <Function>Instantaneous value</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Temperature Difference (1e-2  deg C)</Unit>
-        <Value>1500018</Value>
+        <Value>-18</Value>
     </DataRecord>
 
     <DataRecord id="7">

--- a/test/test-frames/abb_f95.xml
+++ b/test/test-frames/abb_f95.xml
@@ -30,14 +30,14 @@
         <Function>Value during error state</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Power (1e-1 W)</Unit>
-        <Value>144521543</Value>
+        <Value>13110413</Value>
     </DataRecord>
 
     <DataRecord id="3">
         <Function>Value during error state</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Volume flow (1e-4  m^3/h)</Unit>
-        <Value>1521543</Value>
+        <Value>110413</Value>
     </DataRecord>
 
     <DataRecord id="4">

--- a/test/test-frames/electricity-meter-2.xml
+++ b/test/test-frames/electricity-meter-2.xml
@@ -2,7 +2,7 @@
 <MBusData>
 
     <SlaveInformation>
-        <Id>5000345</Id>
+        <Id>5000205</Id>
         <Manufacturer>@@@</Manufacturer>
         <Version>18</Version>
         <ProductName></ProductName>

--- a/test/test-frames/landis+gyr_ultraheat_t230.xml
+++ b/test/test-frames/landis+gyr_ultraheat_t230.xml
@@ -72,7 +72,7 @@
         <Function>Instantaneous value</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Temperature Difference (1e-1  deg C)</Unit>
-        <Value>1500002</Value>
+        <Value>-2</Value>
     </DataRecord>
 
     <DataRecord id="9">

--- a/test/test-frames/siemens_water.xml
+++ b/test/test-frames/siemens_water.xml
@@ -6,7 +6,7 @@
         <Manufacturer>LSE</Manufacturer>
         <Version>153</Version>
         <ProductName>Siemens WFH21</ProductName>
-        <Medium>Hot water</Medium>
+        <Medium>Warm water (30-90°C)</Medium>
         <AccessNumber>235</AccessNumber>
         <Status>00</Status>
         <Signature>0000</Signature>

--- a/test/test-frames/siemens_wfh21.xml
+++ b/test/test-frames/siemens_wfh21.xml
@@ -6,7 +6,7 @@
         <Manufacturer>LSE</Manufacturer>
         <Version>153</Version>
         <ProductName>Siemens WFH21</ProductName>
-        <Medium>Hot water</Medium>
+        <Medium>Warm water (30-90°C)</Medium>
         <AccessNumber>218</AccessNumber>
         <Status>00</Status>
         <Signature>0000</Signature>


### PR DESCRIPTION
It seems it was forgotten to update the test file used by the, and the automatic tests did not fail on it.

2f9fa5c Implement negative BCD number (Type A)
23d8ee4 Added more medium definitions according to DIN EN 13757-7:2018-06 (#162) [UPDATED]

Another problem is that the automatic tests did not give an error on this, I have updates for that as well.
