### PR TITLE
Make mbus_parse_variable_record forward error #169

### DIFF
--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -1455,6 +1455,8 @@ mbus_data_variable_xml_normalized(mbus_data_variable *data)
             }
             else
             {
+                free(buff);
+                return NULL;
             }
 
             len += snprintf(&buff[len], buff_size - len, "    </DataRecord>\n\n");


### PR DESCRIPTION
Update mbus_parse_variable_record so it return NULL if
mbus_parse_variable_record return NULL.
This makes the program mbus_parse_hex exit with non zero exitcode.