### PR TITLE
build-deb.sh: Allow building source packages, pass options

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -1,17 +1,38 @@
 # ------------------------------------------------------------------------------
 #  Copyright (C) 2012, Robert Johansson <rob@raditex.nu>, Raditex Control AB
 #  All rights reserved.
-# 
-#  rSCADA 
+#
+#  rSCADA
 #  http://www.rSCADA.se
 #  info@raditex.nu
-# 
+#
 # ------------------------------------------------------------------------------
 
+# Default settings
+BUILD_BINARY=1
+BUILD_SOURCE=0
+SIGN_KEY=
+
+while [ $# -gt 0 ] && [ "$1" != "--" ]; do
+    case "$1" in
+        --build-source-pkg)
+            BUILD_SOURCE=1
+            ;;
+        --skip-binary)
+            BUILD_BINARY=0
+            ;;
+        --sign-key|-l)
+            SIGN_KEY=$2
+            shift
+            ;;
+    esac
+    shift
+done
+
 if [ ! -f Makefile ]; then
-	#
-	# regenerate automake files
-	#
+    #
+    # regenerate automake files
+    #
     echo "Running autotools..."
 
     autoheader \
@@ -21,5 +42,22 @@ if [ ! -f Makefile ]; then
         && autoconf
 fi
 
-debuild -i -us -uc -b 
+# Determine what build options to pass for source-only,
+# binary-only and binary+source builds.
+BUILD_OPTS=
+if [ ${BUILD_SOURCE} = 1 ]; then
+    if [ ${BUILD_BINARY} = 0 ]; then
+        BUILD_OPTS=-S
+    fi
+elif [ ${BUILD_BINARY} = 1 ]; then
+    BUILD_OPTS=-b
+fi
+
+if [ -n "${SIGN_KEY}" ]; then
+    BUILD_OPTS="${BUILD_OPTS} -k ${SIGN_KEY}"
+else
+    BUILD_OPTS="${BUILD_OPTS} -us -uc"
+fi
+
+debuild -i ${BUILD_OPTS} "$@"
 #sudo pbuilder build $(NAME)_$(VERSION)-1.dsc


### PR DESCRIPTION
Allow end users to build source packages, sign packages with their own
GnuPG key, and perform other interactions with `dpkg-buildpackage`.

The new build script works well for unsigned binaries, but users might want source packages (since then re-building is simple), or might require package signing.  This caters for those use cases.