### PR TITLE
Add ETW-EAX warm water meter

### DIFF
--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -1325,6 +1325,15 @@ mbus_data_product_name(mbus_data_variable_header *header)
                     break;
             }
         }
+        else if (manufacturer == mbus_manufacturer_id("WZG"))
+        {
+            switch (header->version)
+            {
+                case 0x03:
+                    strcpy(buff,"ETW-EAX");
+                    break;
+            }
+        }
         else if (manufacturer == mbus_manufacturer_id("ZRM"))
         {
             switch (header->version)

--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -1330,7 +1330,7 @@ mbus_data_product_name(mbus_data_variable_header *header)
             switch (header->version)
             {
                 case 0x03:
-                    strcpy(buff,"ETW-EAX");
+                    strcpy(buff,"Modularis ETW-EAX");
                     break;
             }
         }


### PR DESCRIPTION
Manufacturer code WZG points to NEUMANN & Co. Wasserzähler Glaubitz
GmbH. The ETW-EAX (and the cold water version ETK-EAX) is sold under
many brands.