### PR TITLE
Improve negative BCD decoding

### DIFF
--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -3289,8 +3289,16 @@ mbus_data_record_decode(mbus_data_record *record)
 
             case 0x09: // 2 digit BCD (8 bit)
 
-                int_val = (int)mbus_data_bcd_decode_hex(record->data, 1);
-                snprintf(buff, sizeof(buff), "%X", int_val);
+                if ((record->drh.dib.dif & MBUS_DATA_RECORD_DIF_MASK_FUNCTION) == 0x30)
+                {
+                    int_val = (int)mbus_data_bcd_decode_hex(record->data, 1);
+                    snprintf(buff, sizeof(buff), "%X", int_val);
+                }
+                else
+                {
+                    int_val = (int)mbus_data_bcd_decode(record->data, 1);
+                    snprintf(buff, sizeof(buff), "%d", int_val);
+                }
 
                 if (debug)
                     printf("%s: DIF 0x%.2x was decoded using 2 digit BCD\n", __PRETTY_FUNCTION__, record->drh.dib.dif);
@@ -3299,8 +3307,16 @@ mbus_data_record_decode(mbus_data_record *record)
 
             case 0x0A: // 4 digit BCD (16 bit)
 
-                int_val = (int)mbus_data_bcd_decode_hex(record->data, 2);
-                snprintf(buff, sizeof(buff), "%X", int_val);
+                if ((record->drh.dib.dif & MBUS_DATA_RECORD_DIF_MASK_FUNCTION) == 0x30)
+                {
+                    int_val = (int)mbus_data_bcd_decode_hex(record->data, 2);
+                    snprintf(buff, sizeof(buff), "%X", int_val);
+                }
+                else
+                {
+                    int_val = (int)mbus_data_bcd_decode(record->data, 2);
+                    snprintf(buff, sizeof(buff), "%d", int_val);
+                }
 
                 if (debug)
                     printf("%s: DIF 0x%.2x was decoded using 4 digit BCD\n", __PRETTY_FUNCTION__, record->drh.dib.dif);
@@ -3309,8 +3325,16 @@ mbus_data_record_decode(mbus_data_record *record)
 
             case 0x0B: // 6 digit BCD (24 bit)
 
-                int_val = (int)mbus_data_bcd_decode_hex(record->data, 3);
-                snprintf(buff, sizeof(buff), "%X", int_val);
+                if ((record->drh.dib.dif & MBUS_DATA_RECORD_DIF_MASK_FUNCTION) == 0x30)
+                {
+                    int_val = (int)mbus_data_bcd_decode_hex(record->data, 3);
+                    snprintf(buff, sizeof(buff), "%X", int_val);
+                }
+                else
+                {
+                    int_val = (int)mbus_data_bcd_decode(record->data, 3);
+                    snprintf(buff, sizeof(buff), "%d", int_val);
+                }
 
                 if (debug)
                     printf("%s: DIF 0x%.2x was decoded using 6 digit BCD\n", __PRETTY_FUNCTION__, record->drh.dib.dif);
@@ -3319,8 +3343,16 @@ mbus_data_record_decode(mbus_data_record *record)
 
             case 0x0C: // 8 digit BCD (32 bit)
 
-                int_val = (int)mbus_data_bcd_decode_hex(record->data, 4);
-                snprintf(buff, sizeof(buff), "%X", int_val);
+                if ((record->drh.dib.dif & MBUS_DATA_RECORD_DIF_MASK_FUNCTION) == 0x30)
+                {
+                    int_val = (int)mbus_data_bcd_decode_hex(record->data, 4);
+                    snprintf(buff, sizeof(buff), "%X", int_val);
+                }
+                else
+                {
+                    int_val = (int)mbus_data_bcd_decode(record->data, 4);
+                    snprintf(buff, sizeof(buff), "%d", int_val);
+                }
 
                 if (debug)
                     printf("%s: DIF 0x%.2x was decoded using 8 digit BCD\n", __PRETTY_FUNCTION__, record->drh.dib.dif);
@@ -3329,8 +3361,16 @@ mbus_data_record_decode(mbus_data_record *record)
 
             case 0x0E: // 12 digit BCD (48 bit)
 
-                long_long_val = mbus_data_bcd_decode_hex(record->data, 6);
-                snprintf(buff, sizeof(buff), "%llX", long_long_val);
+                if ((record->drh.dib.dif & MBUS_DATA_RECORD_DIF_MASK_FUNCTION) == 0x30)
+                {
+                    long_long_val = mbus_data_bcd_decode_hex(record->data, 6);
+                    snprintf(buff, sizeof(buff), "%llX", long_long_val);
+                }
+                else
+                {
+                    long_long_val = mbus_data_bcd_decode(record->data, 6);
+                    snprintf(buff, sizeof(buff), "%lld", long_long_val);
+                }
 
                 if (debug)
                     printf("%s: DIF 0x%.2x was decoded using 12 digit BCD\n", __PRETTY_FUNCTION__, record->drh.dib.dif);

--- a/test/test-frames/SLB_CF-Compact-Integral-MK-MaXX.xml
+++ b/test/test-frames/SLB_CF-Compact-Integral-MK-MaXX.xml
@@ -58,7 +58,7 @@
         <Function>Instantaneous value</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Temperature Difference (1e-2  deg C)</Unit>
-        <Value>F00018</Value>
+        <Value>-18</Value>
     </DataRecord>
 
     <DataRecord id="7">

--- a/test/test-frames/landis+gyr_ultraheat_t230.xml
+++ b/test/test-frames/landis+gyr_ultraheat_t230.xml
@@ -72,7 +72,7 @@
         <Function>Instantaneous value</Function>
         <StorageNumber>0</StorageNumber>
         <Unit>Temperature Difference (1e-1  deg C)</Unit>
-        <Value>F00002</Value>
+        <Value>-2</Value>
     </DataRecord>
 
     <DataRecord id="9">


### PR DESCRIPTION
commit 2f9fa5c introduced handling of F as a negative BCD value. Unfortunately most of the user doesn't benefit from this change. This PR tries to improve the situation.