### PR TITLE
Support IPv6

### DIFF
--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -12,11 +12,8 @@
 #include <limits.h>
 #include <fcntl.h>
 
-#include <sys/socket.h>
 #include <sys/types.h>
-
-#include <arpa/inet.h>
-#include <netinet/in.h>
+#include <sys/socket.h>
 #include <netdb.h>
 
 #include <stdio.h>
@@ -38,11 +35,11 @@ int
 mbus_tcp_connect(mbus_handle *handle)
 {
     char error_str[128], *host;
-    struct hostent *host_addr;
-    struct sockaddr_in s;
+    struct addrinfo hints, *servinfo, *p;
     struct timeval time_out;
     mbus_tcp_data *tcp_data;
-    uint16_t port;
+    char port[5];
+    int status;
 
     if (handle == NULL)
         return -1;
@@ -52,34 +49,34 @@ mbus_tcp_connect(mbus_handle *handle)
         return -1;
 
     host = tcp_data->host;
-    port = tcp_data->port;
+    sprintf(port, "%d", tcp_data->port);
 
-    //
-    // create the TCP connection
-    //
-    if ((handle->fd = socket(AF_INET,SOCK_STREAM, 0)) < 0)
-    {
-        snprintf(error_str, sizeof(error_str), "%s: failed to setup a socket.", __PRETTY_FUNCTION__);
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    if ((status = getaddrinfo(host, port, &hints, &servinfo)) != 0) {
+        snprintf(error_str, sizeof(error_str), "%s: getaddrinfo: %s", __PRETTY_FUNCTION__, gai_strerror(status));
         mbus_error_str_set(error_str);
         return -1;
     }
 
-    s.sin_family = AF_INET;
-    s.sin_port = htons(port);
+    // loop through all the results and connect to the first we can
+    for(p = servinfo; p != NULL; p = p->ai_next) {
+        if ((handle->fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
+            continue;
+        }
 
-    /* resolve hostname */
-    if ((host_addr = gethostbyname(host)) == NULL)
-    {
-        snprintf(error_str, sizeof(error_str), "%s: unknown host: %s", __PRETTY_FUNCTION__, host);
-        mbus_error_str_set(error_str);
-        return -1;
+        if (connect(handle->fd, p->ai_addr, p->ai_addrlen) == -1) {
+            close(handle->fd);
+            continue;
+        }
+
+        break; // if we get here, we must have connected successfully
     }
 
-    memcpy((void *)(&s.sin_addr), (void *)(host_addr->h_addr), host_addr->h_length);
-
-    if (connect(handle->fd, (struct sockaddr *)&s, sizeof(s)) < 0)
-    {
-        snprintf(error_str, sizeof(error_str), "%s: Failed to establish connection to %s:%d", __PRETTY_FUNCTION__, host, port);
+    if (p == NULL) {
+        snprintf(error_str, sizeof(error_str), "%s: failed to connect", __PRETTY_FUNCTION__);
         mbus_error_str_set(error_str);
         return -1;
     }

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -63,19 +63,23 @@ mbus_tcp_connect(mbus_handle *handle)
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 
-    if ((status = getaddrinfo(host, port, &hints, &servinfo)) != 0) {
+    if ((status = getaddrinfo(host, port, &hints, &servinfo)) != 0)
+    {
         snprintf(error_str, sizeof(error_str), "%s: getaddrinfo: %s", __PRETTY_FUNCTION__, gai_strerror(status));
         mbus_error_str_set(error_str);
         return -1;
     }
 
     // loop through all the results and connect to the first we can
-    for(p = servinfo; p != NULL; p = p->ai_next) {
-        if ((handle->fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
+    for (p = servinfo; p != NULL; p = p->ai_next)
+    {
+        if ((handle->fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1)
+        {
             continue;
         }
 
-        if (connect(handle->fd, p->ai_addr, p->ai_addrlen) == -1) {
+        if (connect(handle->fd, p->ai_addr, p->ai_addrlen) == -1)
+        {
             close(handle->fd);
             continue;
         }
@@ -83,7 +87,8 @@ mbus_tcp_connect(mbus_handle *handle)
         break; // if we get here, we must have connected successfully
     }
 
-    if (p == NULL) {
+    if (p == NULL)
+    {
         snprintf(error_str, sizeof(error_str), "%s: failed to connect", __PRETTY_FUNCTION__);
         mbus_error_str_set(error_str);
         return -1;

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -85,7 +85,7 @@ mbus_tcp_connect(mbus_handle *handle)
 
     if (p == NULL)
     {
-        snprintf(error_str, sizeof(error_str), "%s: failed to connect", __PRETTY_FUNCTION__);
+        snprintf(error_str, sizeof(error_str), "%s: Failed to establish connection to %s:%s", __PRETTY_FUNCTION__, host, port);
         mbus_error_str_set(error_str);
         return -1;
     }

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -24,6 +24,7 @@
 #include "mbus-tcp.h"
 
 #define PACKET_BUFF_SIZE 2048
+#define MAX_PORT_SIZE 6 // Size of port number + NULL char
 
 static int tcp_timeout_sec = 4;
 static int tcp_timeout_usec = 0;
@@ -38,7 +39,7 @@ mbus_tcp_connect(mbus_handle *handle)
     struct addrinfo hints, *servinfo, *p;
     struct timeval time_out;
     mbus_tcp_data *tcp_data;
-    char port[5];
+    char port[MAX_PORT_SIZE];
     int status;
 
     if (handle == NULL)
@@ -48,8 +49,15 @@ mbus_tcp_connect(mbus_handle *handle)
     if (tcp_data == NULL || tcp_data->host == NULL)
         return -1;
 
+    // Check if port is in allowed range
+    if ((tcp_data->port < 0) || (tcp_data->port > 0xFFFF))
+    {
+        snprintf(error_str, sizeof(error_str), "%s: Invalid port: %d", __PRETTY_FUNCTION__, tcp_data->port);
+        return -1;
+    }
+
     host = tcp_data->host;
-    sprintf(port, "%d", tcp_data->port);
+    snprintf(port, MAX_PORT_SIZE, "%d", tcp_data->port);
 
     memset(&hints, 0, sizeof hints);
     hints.ai_family = AF_UNSPEC;

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -80,15 +80,15 @@ mbus_tcp_connect(mbus_handle *handle)
         break; // if we get here, we must have connected successfully
     }
 
+    // Free addr info, we do not need it anymore
+    freeaddrinfo(servinfo);
+
     if (p == NULL)
     {
         snprintf(error_str, sizeof(error_str), "%s: failed to connect", __PRETTY_FUNCTION__);
         mbus_error_str_set(error_str);
         return -1;
     }
-
-    // Free addr info, we do not need it anymore
-    freeaddrinfo(servinfo);
 
     // Set a timeout
     time_out.tv_sec  = tcp_timeout_sec;   // seconds

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -49,13 +49,6 @@ mbus_tcp_connect(mbus_handle *handle)
     if (tcp_data == NULL || tcp_data->host == NULL)
         return -1;
 
-    // Check if port is in allowed range
-    if ((tcp_data->port < 0) || (tcp_data->port > 0xFFFF))
-    {
-        snprintf(error_str, sizeof(error_str), "%s: Invalid port: %d", __PRETTY_FUNCTION__, tcp_data->port);
-        return -1;
-    }
-
     host = tcp_data->host;
     snprintf(port, MAX_PORT_SIZE, "%d", tcp_data->port);
 

--- a/mbus/mbus-tcp.c
+++ b/mbus/mbus-tcp.c
@@ -81,6 +81,9 @@ mbus_tcp_connect(mbus_handle *handle)
         return -1;
     }
 
+    // Free addr info, we do not need it anymore
+    freeaddrinfo(servinfo);
+
     // Set a timeout
     time_out.tv_sec  = tcp_timeout_sec;   // seconds
     time_out.tv_usec = tcp_timeout_usec;  // microseconds


### PR DESCRIPTION
Redone TCP connect function. Get rid of deprecated gethostbyname function and replaced it by getaddrinfo, which makes also work IPv6 out-of-box.

Tested
- IPv4
- IPv6
- Hostname (both IPv4 and IPv6)

All working.