### PR TITLE
Initialize i_start and i_end in mbus_scan_2nd_address_range()

### DIFF
--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -2484,6 +2484,10 @@ mbus_scan_2nd_address_range(mbus_handle * handle, int pos, char *addr_mask)
         {
             // mask[pos] is not a wildcard -> don't iterate, recursively check pos+1
             mbus_scan_2nd_address_range(handle, pos+1, mask);
+
+            // Initialize to silence a false-positive compile warning on gcc
+            i_start = 0;
+            i_end = 0;
         }
         else
         {


### PR DESCRIPTION
This is a false-positive produced by gcc e.g. when building with a custom makefile that has -Wmaybe-uninitialized.

This was noted in gcc 16.1.1 but is present in older versions as well.

Resolves these two compile warnings:
warning: 'i_start' may be used uninitialized [-Wmaybe-uninitialized]
warning: 'i_end' may be used uninitialized [-Wmaybe-uninitialized]