### PR TITLE
Update mbus_frame_get_secondary_address() API

### DIFF
--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -2331,7 +2331,8 @@ mbus_probe_secondary_address(mbus_handle *handle, const char *mask, char *matchi
 
             if (mbus_frame_type(&reply) == MBUS_FRAME_TYPE_LONG)
             {
-                char *addr = mbus_frame_get_secondary_address(&reply);
+                char addr_buffer[32];
+                char *addr = mbus_frame_get_secondary_address_to_buffer(&reply, addr_buffer, sizeof(addr_buffer));
 
                 if (addr == NULL)
                 {

--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -5164,8 +5164,20 @@ char *
 mbus_frame_get_secondary_address(mbus_frame *frame)
 {
     static char addr[32];
+    return mbus_frame_get_secondary_address_to_buffer(frame, addr, sizeof(addr));
+}
+
+char *
+mbus_frame_get_secondary_address_to_buffer(mbus_frame *frame, char *output_buffer, size_t output_buffer_size)
+{
     mbus_frame_data *data;
     unsigned long id;
+
+    if (output_buffer_size < 17)
+    {
+        snprintf(error_str, sizeof(error_str), "Output buffer size needs to be at least 17, got %zu.", output_buffer_size);
+        return NULL;
+    }
 
     if (frame == NULL || (data = mbus_frame_data_new()) == NULL)
     {
@@ -5190,7 +5202,7 @@ mbus_frame_get_secondary_address(mbus_frame *frame)
 
     id = (unsigned long) mbus_data_bcd_decode_hex(data->data_var.header.id_bcd, 4);
 
-    snprintf(addr, sizeof(addr), "%08lX%02X%02X%02X%02X",
+    snprintf(output_buffer, output_buffer_size, "%08lX%02X%02X%02X%02X",
              id,
              data->data_var.header.manufacturer[0],
              data->data_var.header.manufacturer[1],
@@ -5200,7 +5212,7 @@ mbus_frame_get_secondary_address(mbus_frame *frame)
     // free data
     mbus_frame_data_free(data);
 
-    return addr;
+    return output_buffer;
 }
 
 //------------------------------------------------------------------------------

--- a/mbus/mbus-protocol.h
+++ b/mbus/mbus-protocol.h
@@ -645,6 +645,14 @@ const char *mbus_vif_unit_lookup(unsigned char vif);
 unsigned char mbus_dif_datalength_lookup(unsigned char dif);
 
 char *mbus_frame_get_secondary_address(mbus_frame *frame);
+
+/**
+ * Decodes the secondary addres into the given buffer.
+ * Note that mbus_frame_get_secondary_address() uses an internal static buffer
+ * which may not be desired in multi-threaded scenarios.
+ */
+char *mbus_frame_get_secondary_address_to_buffer(mbus_frame *frame, char *output_buffer, size_t output_buffer_size);
+
 int   mbus_frame_select_secondary_pack(mbus_frame *frame, char *address);
 
 int mbus_is_primary_address(int value);


### PR DESCRIPTION
This is to remove its static buffer.

Having a static buffer makes use in multi‑threaded scenarios difficult, so the buffer has been removed and replaced with a user‑provided parameter.