### PR TITLE
Remove mbus_slave_data and mbus_slave_data_get()

### DIFF
--- a/mbus/mbus-protocol.c
+++ b/mbus/mbus-protocol.c
@@ -55,11 +55,6 @@ mbus_manufacturer_id(char *manufacturer)
     return (0x0421 <= id && id <= 0x6b5a) ? id : 0;
 }
 
-//------------------------------------------------------------------------------
-// internal data
-//------------------------------------------------------------------------------
-static mbus_slave_data slave_data[MBUS_MAX_PRIMARY_SLAVES];
-
 //
 //  trace callbacks
 //
@@ -97,21 +92,6 @@ void
 mbus_error_reset()
 {
     snprintf(error_str, sizeof(error_str), "no errors");
-}
-
-//------------------------------------------------------------------------------
-/// Return a pointer to the slave_data register. This register can be used for
-/// storing current slave status.
-//------------------------------------------------------------------------------
-mbus_slave_data *
-mbus_slave_data_get(size_t i)
-{
-    if (i < MBUS_MAX_PRIMARY_SLAVES)
-    {
-        return &slave_data[i];
-    }
-
-    return NULL;
 }
 
 //------------------------------------------------------------------------------

--- a/mbus/mbus-protocol.h
+++ b/mbus/mbus-protocol.h
@@ -97,13 +97,6 @@ typedef struct _mbus_frame {
 
 } mbus_frame;
 
-typedef struct _mbus_slave_data {
-
-    int state_fcb;
-    int state_acd;
-
-} mbus_slave_data;
-
 #define NITEMS(x) (sizeof(x)/sizeof(x[0]))
 
 //
@@ -583,11 +576,6 @@ const char *mbus_data_record_value(mbus_data_record *record);
 //
 int mbus_frame_type(mbus_frame *frame);
 int mbus_frame_direction(mbus_frame *frame);
-
-//
-// Slave status data register.
-//
-mbus_slave_data *mbus_slave_data_get(size_t i);
 
 //
 // XML generating functions


### PR DESCRIPTION
The static variable takes space for everyone using this library. Those who want to store this kind of state can store it outside the library since its not maintained by the library itself.