### PR TITLE
Add user managed pointer to mbus_handle

### DIFF
--- a/mbus/mbus-protocol-aux.c
+++ b/mbus/mbus-protocol-aux.c
@@ -1527,6 +1527,7 @@ mbus_context_serial(const char *device)
     handle->is_serial = 1;
     handle->purge_first_frame = MBUS_FRAME_PURGE_M2S;
     handle->auxdata = serial_data;
+    handle->userdata = NULL;
     handle->open = mbus_serial_connect;
     handle->close = mbus_serial_disconnect;
     handle->recv = mbus_serial_recv_frame;
@@ -1575,6 +1576,7 @@ mbus_context_tcp(const char *host, uint16_t port)
     handle->is_serial = 0;
     handle->purge_first_frame = MBUS_FRAME_PURGE_M2S;
     handle->auxdata = tcp_data;
+    handle->userdata = NULL;
     handle->open = mbus_tcp_connect;
     handle->close = mbus_tcp_disconnect;
     handle->recv = mbus_tcp_recv_frame;
@@ -1669,6 +1671,19 @@ mbus_context_set_option(mbus_handle * handle, mbus_context_option option, long v
     }
 
     return -1; // unable to set option
+}
+
+int
+mbus_context_set_userdata(mbus_handle * handle, void *userdata)
+{
+    if (handle == NULL)
+    {
+        MBUS_ERROR("%s: Invalid M-Bus handle to set userdata.\n", __PRETTY_FUNCTION__);
+        return -1;
+    }
+
+    handle->userdata = userdata;
+    return 0;
 }
 
 int

--- a/mbus/mbus-protocol-aux.h
+++ b/mbus/mbus-protocol-aux.h
@@ -99,6 +99,7 @@ typedef struct _mbus_handle {
     void (*scan_progress) (struct _mbus_handle *handle, const char *mask);
     void (*found_event) (struct _mbus_handle *handle, mbus_frame *frame);    
     void *auxdata;
+    void *userdata; /**< User‑managed pointer for callback context */
 } mbus_handle;
 
 /**
@@ -223,6 +224,16 @@ int mbus_disconnect(mbus_handle * handle);
  * @return Zero when successful.
  */
 int mbus_context_set_option(mbus_handle * handle, mbus_context_option option, long value);
+
+/**
+ * Set the user-managed data of a M-Bus context (e.g. for callback context).
+ *
+ * @param handle   Initialized handle
+ * @param userdata User‑managed pointer
+ *
+ * @return Zero when successful.
+ */
+int mbus_context_set_userdata(mbus_handle * handle, void *userdata);
 
 /**
  * Receives a frame using "unified" handle


### PR DESCRIPTION
This is to provide custom user context for scan callbacks.